### PR TITLE
New flag: `-fno-abigen`

### DIFF
--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -30,6 +30,7 @@ struct Configuration {
   bool AllowUndefined;
   bool CompressRelocTargets;
   bool Demangle;
+  bool DisableAbigen;
   bool DisableVerify;
   bool ExportAll;
   bool ExportTable;

--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -30,7 +30,6 @@ struct Configuration {
   bool AllowUndefined;
   bool CompressRelocTargets;
   bool Demangle;
-  bool DisableAbigen;
   bool DisableVerify;
   bool ExportAll;
   bool ExportTable;
@@ -38,6 +37,7 @@ struct Configuration {
   bool ImportMemory;
   bool ImportTable;
   bool MergeDataSegments;
+  bool NoAbigen;
   bool PrintGcSections;
   bool Relocatable;
   bool SaveTemps;

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -318,6 +318,7 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
 
   Config->AllowUndefined = Args.hasArg(OPT_allow_undefined);
   Config->Demangle = Args.hasFlag(OPT_demangle, OPT_no_demangle, true);
+  Config->DisableAbigen = Args.hasArg(OPT_disable_abigen);
   Config->DisableVerify = Args.hasArg(OPT_disable_verify);
   Config->Entry = getEntry(Args, Args.hasArg(OPT_relocatable) ? "" : "_start");
   Config->ExportAll = Args.hasArg(OPT_export_all);
@@ -523,6 +524,7 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
   // Do size optimizations: garbage collection
   markLive();
 
+  std::cout << "VALUE OF OPT_DISABLE_ABIGEN " << OPT_disable_abigen << "\n";
   // Write the result to the file.
-  writeResult(true);
+  writeResult(OPT_disable_abigen);
 }

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -524,7 +524,11 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
   // Do size optimizations: garbage collection
   markLive();
 
-  std::cout << "VALUE OF OPT_DISABLE_ABIGEN " << OPT_disable_abigen << "\n";
-  // Write the result to the file.
-  writeResult(OPT_disable_abigen);
+  // Write the result to the file
+  if (Config->NoAbigen) {
+     writeResult(false);
+  }
+  else {
+     writeResult(true);
+  }
 }

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -27,6 +27,9 @@ defm demangle: B<"demangle",
     "Demangle symbol names",
     "Do not demangle symbol names">;
 
+def disable_abigen: F<"disable-abigen">,
+  HelpText<"Do not generate a corresponding abi file">;
+
 def entry: S<"entry">, MetaVarName<"<entry>">,
   HelpText<"Name of entry point symbol">;
 

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -27,9 +27,6 @@ defm demangle: B<"demangle",
     "Demangle symbol names",
     "Do not demangle symbol names">;
 
-def disable_abigen: F<"disable-abigen">,
-  HelpText<"Do not generate a corresponding abi file">;
-
 def entry: S<"entry">, MetaVarName<"<entry>">,
   HelpText<"Name of entry point symbol">;
 
@@ -59,6 +56,9 @@ def L: JoinedOrSeparate<["-"], "L">, MetaVarName<"<dir>">,
   HelpText<"Add a directory to the library search path">;
 
 def mllvm: S<"mllvm">, HelpText<"Options to pass to LLVM">;
+
+def no_abigen: F<"no-abigen">,
+  HelpText<"Disable ABI file generation">;
 
 def no_threads: F<"no-threads">,
   HelpText<"Do not run the linker multi-threaded">;


### PR DESCRIPTION
Cross reference to the change in repository `EOSIO/eosio.cdt` [#517](https://github.com/EOSIO/eosio.cdt/pull/517).
The default behavior of `eosio-ld` is to automatically generate an `.abi` file for the user. With the additional of this new flag, `-fno-abigen`, the user can now specify whether or not an `.abi` should be generated by the linker.