### PR TITLE
Sync submodule and fix for `wasm-ld` hanging due to use of non-reentrant function.

### DIFF
--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -22,7 +22,7 @@ namespace wasm {
 struct Configuration {
   inline bool should_export(const llvm::wasm::WasmExport& ex)const {
      for (auto x : exports) {
-        if ((x.Name == ex.Name || x.Name == "*") && x.Kind == ex.Kind)
+        if ((memcmp(x.Name.str().c_str(), ex.Name.str().c_str(), ex.Name.size()) == 0 || x.Name.str()[0] == '*') && x.Kind == ex.Kind)
            return true;
      }
      return false;

--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -37,6 +37,7 @@ struct Configuration {
   bool ImportMemory;
   bool ImportTable;
   bool MergeDataSegments;
+  bool OtherModel;
   bool PrintGcSections;
   bool Relocatable;
   bool SaveTemps;

--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -36,6 +36,7 @@ struct Configuration {
   bool GcSections;
   bool ImportMemory;
   bool ImportTable;
+  bool OtherModel;
   bool MergeDataSegments;
   bool PrintGcSections;
   bool Relocatable;

--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -38,7 +38,6 @@ struct Configuration {
   bool ImportTable;
   bool OtherModel;
   bool MergeDataSegments;
-  bool OtherModel;
   bool PrintGcSections;
   bool Relocatable;
   bool SaveTemps;

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -409,7 +409,7 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
         make<SyntheticFunction>(NullSignature, "__wasm_call_ctors"));
 
     static WasmSignature EntrySignature;
-    if (Config->OtherModel)
+    if (!Config->OtherModel)
        EntrySignature = {{WASM_TYPE_I64, WASM_TYPE_I64, WASM_TYPE_I64}, WASM_TYPE_NORESULT};
     else
        EntrySignature = {{}, WASM_TYPE_NORESULT};

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -459,6 +459,8 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
   if (errorCount())
     return;
 
+  Config->OtherModel = OPT_other_model;
+     
   // Make sure we have resolved all symbols.
   if (!Config->Relocatable && !Config->AllowUndefined) {
     Symtab->reportRemainingUndefines();

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -457,7 +457,9 @@ void LinkerDriver::link(ArrayRef<const char *> ArgsArr) {
        if (toString(*Sym) == Config->Entry)
           Symtab->EntryIsUndefined = false;
      }
-
+   
+   if (Config->OtherModel && Symtab->EntryIsUndefined)
+      error("entry symbol ("+Config->Entry+") is not defined");
   // Do link-time optimization if given files are LLVM bitcode files.
   // This compiles bitcode files into real object files.
   Symtab->addCombinedLTOObject();

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -138,9 +138,6 @@ def other_model: F<"other-model">,
 def stack_first: F<"stack-first">,
   HelpText<"Place stack at start of linear memory rather than after data">;
 
-def other_model: F<"other-model">,
-  HelpText<"Do not autogen a dispatcher">;
-
 // Aliases
 def alias_entry_e: JoinedOrSeparate<["-"], "e">, Alias<entry>;
 def alias_entry_entry: J<"entry=">, Alias<entry>;

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -132,6 +132,9 @@ def max_memory: J<"max-memory=">,
 def no_entry: F<"no-entry">,
   HelpText<"Do not output any entry point">;
 
+def other_model: F<"other-model">,
+  HelpText<"Linking with a model other than EOSIO smart contract">;
+
 def stack_first: F<"stack-first">,
   HelpText<"Place stack at start of linear memory rather than after data">;
 

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -135,6 +135,9 @@ def no_entry: F<"no-entry">,
 def stack_first: F<"stack-first">,
   HelpText<"Place stack at start of linear memory rather than after data">;
 
+def other_model: F<"other-model">,
+  HelpText<"Do not autogen a dispatcher">;
+
 // Aliases
 def alias_entry_e: JoinedOrSeparate<["-"], "e">, Alias<entry>;
 def alias_entry_entry: J<"entry=">, Alias<entry>;

--- a/wasm/OutputSections.cpp
+++ b/wasm/OutputSections.cpp
@@ -109,8 +109,8 @@ void CodeSection::writeTo(uint8_t *Buf) {
   memcpy(Buf, CodeSectionHeader.data(), CodeSectionHeader.size());
 
   // Write code section bodies
-  parallelForEach(Functions,
-                  [&](const InputChunk *Chunk) { Chunk->writeTo(Buf); });
+  for (const InputChunk *Chunk : Functions)
+    Chunk->writeTo(Buf);
 }
 
 uint32_t CodeSection::numRelocations() const {
@@ -166,7 +166,7 @@ void DataSection::writeTo(uint8_t *Buf) {
   // Write data section headers
   memcpy(Buf, DataSectionHeader.data(), DataSectionHeader.size());
 
-  parallelForEach(Segments, [&](const OutputSegment *Segment) {
+  for (const OutputSegment *Segment : Segments) {
     // Write data segment header
     uint8_t *SegStart = Buf + Segment->SectionOffset;
     memcpy(SegStart, Segment->Header.data(), Segment->Header.size());
@@ -174,7 +174,7 @@ void DataSection::writeTo(uint8_t *Buf) {
     // Write segment data payload
     for (const InputChunk *Chunk : Segment->InputSegments)
       Chunk->writeTo(Buf);
-  });
+  };
 }
 
 uint32_t DataSection::numRelocations() const {
@@ -222,8 +222,8 @@ void CustomSection::writeTo(uint8_t *Buf) {
   Buf += NameData.size();
 
   // Write custom sections payload
-  parallelForEach(InputSections,
-                  [&](const InputSection *Section) { Section->writeTo(Buf); });
+  for (const InputSection *Section : InputSections)
+    Section->writeTo(Buf);
 }
 
 uint32_t CustomSection::numRelocations() const {

--- a/wasm/SymbolTable.cpp
+++ b/wasm/SymbolTable.cpp
@@ -221,8 +221,10 @@ Symbol *SymbolTable::addDefinedFunction(StringRef Name, uint32_t Flags,
     return S;
   }
 
-  if (Function)
-    checkFunctionType(S, File, &Function->Signature);
+  if (Function) {
+    if (Name != Config->Entry)
+       checkFunctionType(S, File, &Function->Signature);
+  }
 
   if (shouldReplace(S, File, Flags))
     replaceSymbol<DefinedFunction>(S, Name, Flags, File, Function);

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1358,7 +1358,7 @@ void Writer::run(bool is_entry_defined) {
   if (!Config->Relocatable)
     createCtorFunction();
 
-  if (Symtab->EntryIsUndefined)
+  if (!Config->OtherModel && Symtab->EntryIsUndefined)
      createDispatchFunction();
 
   log("-- calculateTypes");

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -303,7 +303,7 @@ void Writer::createExportSection() {
 
   SyntheticSection *Section = createSyntheticSection(WASM_SEC_EXPORT);
   raw_ostream &OS = Section->getStream();
-
+   
   std::vector<WasmExport> filtered_exports;
   for (auto ex : Exports) {
      if (Config->should_export(ex))

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1119,22 +1119,13 @@ void Writer::createDispatchFunction() {
             }
          }
       }
-
-      writeU8(OS, OPCODE_GET_LOCAL, "GET_LOCAL");
-      writeUleb128(OS, 0, "self");
-      writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
-      encodeSLEB128((int64_t)eosio::cdt::string_to_name("eosio"), OS);
-      writeU8(OS, OPCODE_I64_NE, "I64.NE");
-      writeU8(OS, OPCODE_IF, "if receiver != eosio");
-      writeU8(OS, 0x40, "none");
       
       // check for onerror first
       bool has_onerror_handler = false;
       if (not_cnt > 0) {
          for (auto const& notif0 : notify_handlers) {
-            if (notif0.first == "eosio") {
+            if (notif0.first == "*") {
                for (auto const& notif1 : notif0.second) {
-                  llvm::outs() << "notif1 " << notif1.substr(0, notif1.find(":")) << "\n";
                   if (notif1.substr(0, notif1.find(":")) == "onerror") {
                      has_onerror_handler = true;
                   }
@@ -1145,15 +1136,6 @@ void Writer::createDispatchFunction() {
 
       if (!has_onerror_handler) {
          // assert on onerror
-         writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
-         uint64_t acnt = eosio::cdt::string_to_name("eosio");
-         encodeSLEB128((int64_t)acnt, OS);
-         writeU8(OS, OPCODE_GET_LOCAL, "GET_LOCAL");
-         writeUleb128(OS, 1, "code");
-         writeU8(OS, OPCODE_I64_EQ, "I64.EQ");
-         writeU8(OS, OPCODE_IF, "IF code == eosio");
-         writeU8(OS, 0x40, "none");
-
          writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
          uint64_t nm = eosio::cdt::string_to_name("onerror");
          encodeSLEB128((int64_t)nm, OS);
@@ -1168,7 +1150,6 @@ void Writer::createDispatchFunction() {
          encodeSLEB128((int64_t)EOSIO_ERROR_ONERROR, OS);
          writeU8(OS, OPCODE_CALL, "CALL");
          writeUleb128(OS, assert_idx, "code");
-         writeU8(OS, OPCODE_END, "END");
          writeU8(OS, OPCODE_END, "END");
       }
 

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1132,12 +1132,14 @@ void Writer::createDispatchFunction() {
       bool has_onerror_handler = false;
       if (not_cnt > 0) {
          for (auto const& notif0 : notify_handlers) {
-            if (notif0.first == "eosio")
-               for (auto const& notif1 : notif0.second)
-                  if (notif1 == "onerror") {
+            if (notif0.first == "eosio") {
+               for (auto const& notif1 : notif0.second) {
+                  llvm::outs() << "notif1 " << notif1.substr(0, notif1.find(":")) << "\n";
+                  if (notif1.substr(0, notif1.find(":")) == "onerror") {
                      has_onerror_handler = true;
-                     break;
                   }
+               }
+            }
          }
       }
 

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1081,7 +1081,7 @@ void Writer::createDispatchFunction() {
         writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
         encodeSLEB128((int64_t)EOSIO_ERROR_NO_ACTION, OS);
         writeU8(OS, OPCODE_CALL, "CALL");
-        writeUleb128(OS, *(uint32_t*)&assert_idx, "code");
+        writeUleb128(OS, assert_idx, "code");
       } else {
          fatal("fatal failure: contract with no actions and trying to create dispatcher"); 
       }
@@ -1162,7 +1162,7 @@ void Writer::createDispatchFunction() {
          writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
          encodeSLEB128((int64_t)EOSIO_ERROR_ONERROR, OS);
          writeU8(OS, OPCODE_CALL, "CALL");
-         writeUleb128(OS, *(uint32_t*)&assert_idx, "code");
+         writeUleb128(OS, assert_idx, "code");
          writeU8(OS, OPCODE_END, "END");
          writeU8(OS, OPCODE_END, "END");
       }

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1170,10 +1170,12 @@ void Writer::createDispatchFunction() {
       // dispatch notification handlers
       bool notify0_need_else = false;
       if (not_cnt > 0) {
+         bool has_written = false;
          for (auto const& notif0 : notify_handlers) {
             uint64_t nm = eosio::cdt::string_to_name(notif0.first.c_str());
             if (notif0.first == "*")
                continue;
+            has_written = true;
             if (notify0_need_else)
                writeU8(OS, OPCODE_ELSE, "ELSE");
             writeU8(OS, OPCODE_I64_CONST, "I64.CONST");
@@ -1190,7 +1192,8 @@ void Writer::createDispatchFunction() {
                writeU8(OS, OPCODE_END, "END");
             notify0_need_else = true;
          }
-         writeU8(OS, OPCODE_ELSE, "ELSE");
+         if (has_written)
+            writeU8(OS, OPCODE_ELSE, "ELSE");
       }
 
       if (!notify_handlers["*"].empty()) {

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -125,7 +125,7 @@ private:
      } catch (std::runtime_error& err) {
         fatal(std::string(std::string("failed to write abi: ") + err.what()).c_str());
      } catch (jsoncons::json_exception& ex) {
-        fatal(std::string(std::string("failed to write abi") + ex.what()).c_str());
+        log("failed to write ABI");
      }
   }
 
@@ -1186,7 +1186,7 @@ void Writer::createDispatchFunction() {
             bool need_else = false;
             for (auto const& notif1 : notif0.second)
                create_if(OS, notif1, need_else);
-            for (auto const& notif1 : notif0.second)
+            for (int i=0; i < notif0.second.size(); i++)
                writeU8(OS, OPCODE_END, "END");
             notify0_need_else = true;
          }


### PR DESCRIPTION
Addresses issues:
`eosio.cdt`: [123](https://github.com/EOSIO/eosio.cdt/issues/123), [126](https://github.com/EOSIO/eosio.cdt/issues/126), [288](https://github.com/EOSIO/eosio.cdt/issues/288), [446](https://github.com/EOSIO/eosio.cdt/issues/446), [471](https://github.com/EOSIO/eosio.cdt/issues/471), [556](https://github.com/EOSIO/eosio.cdt/issues/556), [741](https://github.com/EOSIO/eosio.cdt/issues/741)
`eos`: [6668](https://github.com/EOSIO/eos/issues/6668)

[`parallelForEach`](https://github.com/EOSIO/lld/blob/8989c8680788e1792699cf2549c1ec8185917ffe/include/lld/Common/Threads.h#L69-L74) is a non-reentrant function. Thus when `wasm-ld` is attempting to write multiple `InputSections` with `parallelForEach`, a deadlock occurs. This fix addresses this behavior by forcing `wasm-ld` to write the the multiple `InputSections` with no parallelism.

Reference: [Fix a crash bug caused by a nested call of parallelForEach](https://github.com/llvm/llvm-project/commit/5081e41bdae2eb14a3f3eb8810263f9fea8fc7c1).