### PR TITLE
Fix handling of undefined symbols.

### DIFF
--- a/wasm/InputFiles.cpp
+++ b/wasm/InputFiles.cpp
@@ -173,7 +173,7 @@ uint32_t ObjFile::calcNewValue(const WasmRelocation &reloc) const {
   case R_WASM_MEMORY_ADDR_I32:
   case R_WASM_MEMORY_ADDR_LEB:
   case R_WASM_MEMORY_ADDR_REL_SLEB:
-    if (isa<UndefinedData>(sym))
+    if (isa<UndefinedData>(sym) || sym->isUndefWeak())
       return 0;
     return cast<DefinedData>(sym)->getVirtualAddress() + reloc.Addend;
   case R_WASM_TYPE_INDEX_LEB:

--- a/wasm/Relocations.cpp
+++ b/wasm/Relocations.cpp
@@ -9,6 +9,7 @@
 #include "Relocations.h"
 
 #include "InputChunks.h"
+#include "SymbolTable.h"
 #include "SyntheticSections.h"
 
 using namespace llvm;
@@ -30,15 +31,10 @@ static bool allowUndefined(const Symbol* sym) {
   if (isa<DataSymbol>(sym))
     return false;
 
-  bool isAllowed = config->allowUndefined || config->allowUndefinedSymbols.count(sym->getName()) != 0;
-  if (!isAllowed) {
-    for (const auto *s : out.importSec->importedSymbols) {
-      if (sym->getName() == s->getName()) {
-        isAllowed = true;
-      }
-    }
-  }
-  return isAllowed;
+  bool isConfigAllowed = config->allowUndefined || config->allowUndefinedSymbols.count(sym->getName()) != 0;
+  bool isAllowed = symtab->allowed.count(sym->getName());
+
+  return isConfigAllowed || isAllowed;
 }
 
 static void reportUndefined(const Symbol* sym) {


### PR DESCRIPTION
The previous code introduced a bug where all undefined symbols were treated as imports, which lead to runtime errors rather than compile time errors