### PR TITLE
option for printing link directories added

### DIFF
--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/TarWriter.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/FileUtilities.h"
 
 #define DEBUG_TYPE "lld"
 
@@ -706,6 +707,11 @@ void LinkerDriver::link(ArrayRef<const char *> argsArr) {
 
   if (auto *arg = args.getLastArg(OPT_allow_undefined_file))
     readImportFile(arg->getValue());
+  
+  if (args.hasArg(OPT_eosio_link_dirs)){
+    message("Library paths:");
+    llvm::printOptions("", config->searchPaths, outs(), errs());
+  }
 
   if (!args.hasArg(OPT_INPUT)) {
     error("no input files");

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -205,3 +205,5 @@ def thinlto_cache_dir: J<"thinlto-cache-dir=">,
   HelpText<"Path to ThinLTO cached object file directory">;
 defm thinlto_cache_policy: Eq<"thinlto-cache-policy", "Pruning policy for the ThinLTO cache">;
 def thinlto_jobs: J<"thinlto-jobs=">, HelpText<"Number of ThinLTO jobs">;
+
+def eosio_link_dirs: F<"eosio-link-dirs">, HelpText<"Print search directories for library search">;


### PR DESCRIPTION
Task description:
* Add option -eosio-include-dirs which would print the set of include paths that the compiler will be looking at.
this should be available via eosio-cc, eosio-cpp
* Add option -eosio-link-dirs which would be the directories that the linker will be looking at during execution
eosio-cc, eosio-cpp and eosio-ld

This PR adds printing directories to wasm-ld linker that is invoked by eosio-ld