### PR TITLE
Fix wasm size bloating

### DIFF
--- a/wasm/MarkLive.cpp
+++ b/wasm/MarkLive.cpp
@@ -106,7 +106,13 @@ void lld::wasm::markLive() {
         }
      }
      for (const auto& import : wasmObj->imports()) {
-        enqueue(symtab->find(import.Field));
+        if (auto* sym = symtab->find(import.Field)) {
+          for (const auto& allowed : wasmObj->allowed_imports()) {
+            if (allowed == sym->getName()) {
+              enqueue(sym);
+            }
+          }
+        }
      }
   }
 

--- a/wasm/MarkLive.cpp
+++ b/wasm/MarkLive.cpp
@@ -107,12 +107,9 @@ void lld::wasm::markLive() {
         }
      }
      for (const auto& import : wasmObj->imports()) {
-        if (auto* sym = symtab->find(import.Field)) {
-          for (const auto& allowed : wasmObj->allowed_imports()) {
-            if (allowed == sym->getName()) {
-              enqueue(sym);
-            }
-          }
+        if (import.Field == "__wasm_call_ctors" || import.Field == "__cxa_finalize" ||
+            std::find(wasmObj->allowed_imports().begin(), wasmObj->allowed_imports().end(), import.Field) != wasmObj->allowed_imports().end()) {
+           enqueue(symtab->find(import.Field));
         }
      }
   }

--- a/wasm/MarkLive.cpp
+++ b/wasm/MarkLive.cpp
@@ -89,12 +89,13 @@ void lld::wasm::markLive() {
   for (const ObjFile* obj : symtab->objectFiles) {
      const auto& wasmObj = obj->getWasmObj();
      for (const auto& func : wasmObj->functions()) {
+        if (func.SymbolName == "pre_dispatch" || func.SymbolName == "post_dispatch" || func.SymbolName == "eosio_assert_code" ||
+            func.SymbolName == "eosio_set_contract_name") {
+           enqueue(symtab->find(func.SymbolName));
+           }
+
         for (const auto& action : wasmObj->actions()) {
            if (func.SymbolName == action.substr(action.find(":")+1)) {
-              enqueue(symtab->find(func.SymbolName));
-           }
-           if (func.SymbolName == "pre_dispatch" || func.SymbolName == "post_dispatch" || func.SymbolName == "eosio_assert_code" ||
-               func.SymbolName == "eosio_set_contract_name") {
               enqueue(symtab->find(func.SymbolName));
            }
         }

--- a/wasm/MarkLive.cpp
+++ b/wasm/MarkLive.cpp
@@ -92,17 +92,19 @@ void lld::wasm::markLive() {
         if (func.SymbolName == "pre_dispatch" || func.SymbolName == "post_dispatch" || func.SymbolName == "eosio_assert_code" ||
             func.SymbolName == "eosio_set_contract_name") {
            enqueue(symtab->find(func.SymbolName));
-           }
-
+           continue;
+        }
         for (const auto& action : wasmObj->actions()) {
            if (func.SymbolName == action.substr(action.find(":")+1)) {
               enqueue(symtab->find(func.SymbolName));
+              break;
            }
         }
         for (const auto& notify : wasmObj->notify()) {
            std::string sub = notify.substr(notify.find(":")+2);
            if (func.SymbolName == sub.substr(sub.find(":")+1)) {
               enqueue(symtab->find(func.SymbolName));
+              break;
            }
         }
      }


### PR DESCRIPTION
This PR fixes the WASM bloating issue introduced by marking all functions in involved object files as "live". 