### PR TITLE
Let wasm-ld support --no-abigen parameter which is passed from eosio-cpp

### DIFF
--- a/wasm/Config.h
+++ b/wasm/Config.h
@@ -38,6 +38,7 @@ struct Configuration {
   bool passiveSegments;
   bool importTable;
   bool mergeDataSegments;
+  bool noAbigen;
   bool pie;
   bool printGcSections;
   bool relocatable;

--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -310,6 +310,7 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasFlag(OPT_check_features, OPT_no_check_features, true);
   config->compressRelocations = args.hasArg(OPT_compress_relocations);
   config->demangle = args.hasFlag(OPT_demangle, OPT_no_demangle, true);
+  config->noAbigen = args.hasArg(OPT_no_abigen);
   config->disableVerify = args.hasArg(OPT_disable_verify);
   config->emitRelocs = args.hasArg(OPT_emit_relocs);
   config->entry = getEntry(args);

--- a/wasm/Options.td
+++ b/wasm/Options.td
@@ -67,6 +67,9 @@ def L: JoinedOrSeparate<["-"], "L">, MetaVarName<"<dir>">,
 
 def mllvm: S<"mllvm">, HelpText<"Options to pass to LLVM">;
 
+def no_abigen: F<"no-abigen">,
+  HelpText<"Disable ABI file generation">;
+
 def no_threads: F<"no-threads">,
   HelpText<"Do not run the linker multi-threaded">;
 

--- a/wasm/Writer.cpp
+++ b/wasm/Writer.cpp
@@ -1278,7 +1278,10 @@ void Writer::run(bool undefinedEntry) {
   if (errorCount())
     return;
 
-  writeABI();
+  if (!config->noAbigen) {
+    writeABI();
+  }
+
   if (Error e = buffer->commit())
     fatal("failed to write the output file: " + toString(std::move(e)));
 }


### PR DESCRIPTION
Let wasm-ld support --no-abigen parameter which is passed from eosio-cpp.
Details see EPE953, when using eosio-cpp --no-abigen xxxcontract.cpp, wasm-ld pops error, this PR fix that.